### PR TITLE
Call the README file README.md

### DIFF
--- a/gap/PackageMaker.gi
+++ b/gap/PackageMaker.gi
@@ -415,7 +415,7 @@ InstallGlobalFunction( PackageWizard, function()
         Add(pkginfo.PackageWWWHome, '/');
     fi;
 
-    pkginfo.README_URL     := "Concatenation( ~.PackageWWWHome, \"README\" )";
+    pkginfo.README_URL     := "Concatenation( ~.PackageWWWHome, \"README.md\" )";
     pkginfo.PackageInfoURL := "Concatenation( ~.PackageWWWHome, \"PackageInfo.g\" )";
 
     kernel := AskAlternativesQuestion("Shall your package provide a GAP kernel extension?",
@@ -501,7 +501,7 @@ InstallGlobalFunction( PackageWizard, function()
         Error("Failed to create package directory");
     fi;
 
-    TranslateTemplate(fail, "README", pkginfo );
+    TranslateTemplate(fail, "README.md", pkginfo );
     TranslateTemplate("PackageInfo.g.in", "PackageInfo.g", pkginfo );
     TranslateTemplate(fail, "init.g", pkginfo );
     TranslateTemplate(fail, "read.g", pkginfo );


### PR DESCRIPTION
This changes the code to generate `README.md` instead of `README`, since I keep renaming this file, and it irritates me (and the default location for packages is some webservice).